### PR TITLE
🐛fix: Attach onClick Event on the button

### DIFF
--- a/src/commons/Fields/LinkField.jsx
+++ b/src/commons/Fields/LinkField.jsx
@@ -13,11 +13,11 @@ export default function LinkField({
 
   return (
     <div>
-      <Button type="button">
-        <a
-          href={url}
-          onClick={handleClick}
-        >
+      <Button
+        type="button"
+        onClick={handleClick}
+      >
+        <a href={url}>
           {title}
         </a>
       </Button>


### PR DESCRIPTION
The clicking button hasn't redirected users to the expected destination. 

Pull up handling onClick event from anchor to the parent element.