### PR TITLE
fix 🐛: Hide Message 'Saving Once is enough'

### DIFF
--- a/src/pages/NewProfile/NewProfile.jsx
+++ b/src/pages/NewProfile/NewProfile.jsx
@@ -123,9 +123,11 @@ export default function NewProfile({ onChange, onSubmit, profile }) {
               <Button type="submit">
                 저장하기 👌
               </Button>
-              <GuideLines success>
-                ※ 이번 한번만 저장하시면 됩니다.
-              </GuideLines>
+              {profile.isNew && (
+                <GuideLines success>
+                  ※ 이번 한번만 저장하시면 됩니다.
+                </GuideLines>
+              )}
             </>
           ) : (
             <>

--- a/src/pages/NewProfile/NewProfile.test.jsx
+++ b/src/pages/NewProfile/NewProfile.test.jsx
@@ -20,7 +20,16 @@ describe('NewProfile', () => {
     currentBalance: 10000,
   };
 
+  const newPorifle = {
+    isNew: true,
+    name: 'tak',
+    age: '29',
+    monthlySavings: 5000,
+    currentBalance: 10000,
+  };
+
   const renderNewProfile = ({
+    isNew,
     name,
     age,
     monthlySavings,
@@ -30,6 +39,7 @@ describe('NewProfile', () => {
       onChange={handleChange}
       onSubmit={handleClick}
       profile={{
+        isNew,
         name,
         age,
         monthlySavings,
@@ -62,5 +72,13 @@ describe('NewProfile', () => {
 
     expect(screen.getByText('5,000만 원')).toBeInTheDocument();
     expect(screen.getByText('1억 원')).toBeInTheDocument();
+  });
+
+  context('with new profile', () => {
+    it("renders message '이번 한번만 저장하시면 됩니다.'", () => {
+      renderNewProfile(newPorifle);
+
+      expect(screen.getByText(/한번만/)).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Fix of problem that users who already entered their info view the guideline message '이번 한번만 저장하시면 됩니다.'

![hide_message](https://user-images.githubusercontent.com/77006427/116806653-823ec680-ab69-11eb-8972-9c9eb52e00bb.gif)
