### PR TITLE
fix 🐛:  Config scrollTo window property

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,4 @@
 import '@testing-library/jest-dom';
+
+const NOOP = () => {};
+Object.defineProperty(window, 'scrollTo', { value: NOOP, writable: true });

--- a/src/commons/Fields/LinkField.test.jsx
+++ b/src/commons/Fields/LinkField.test.jsx
@@ -8,8 +8,10 @@ describe('LinkField', () => {
   const handleClick = jest.fn();
   const changeApartment = jest.fn();
 
+  window.scrollTo = jest.fn();
+
   beforeEach(() => {
-    jest.clearAllMocks();
+    window.scrollTo.mockClear();
   });
 
   context("with '내 정보 입력하러가기' title", () => {
@@ -42,6 +44,7 @@ describe('LinkField', () => {
         name: '거주하고 싶은 아파트 둘러보기',
       }));
 
+      expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
       expect(handleClick).toBeCalledWith({ url: '/apartments' });
     });
   });
@@ -67,6 +70,7 @@ describe('LinkField', () => {
       name: '보기',
     }));
 
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
     expect(handleClick).toBeCalled();
     expect(changeApartment).toBeCalled();
   });


### PR DESCRIPTION
jsdom provides the actual browser method, but it does not implement anything.

Defining the object property assigns the implementation.

Expected Scrolling Behavior must be tested where it's being used.

See Also:
- https://jestjs.io/docs/configuration#testenvironment-string
- https://github.com/jsdom/jsdom/blob/b83783da63deeb7c5602b024a92e214df423a412/lib/jsdom/browser/Window.js#L611
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty