### PR TITLE
remove 🔥: delete disfavored apartment types

### DIFF
--- a/src/fixtures/apartments/categories.js
+++ b/src/fixtures/apartments/categories.js
@@ -23,26 +23,6 @@ const CATEGORIES = [
     title: '#제일 비싼',
     url: 'rank',
   },
-  {
-    title: '#주변 상권 우수',
-    url: 'commercial',
-  },
-  {
-    title: '#조경 우수',
-    url: 'landscape',
-  },
-  {
-    title: '#강남 출퇴근 편리',
-    url: 'commute_gangnam',
-  },
-  {
-    title: '#광화문 출퇴근 편리',
-    url: 'commute_gwanghwamun',
-  },
-  {
-    title: '#여의도 출퇴근 편리',
-    url: 'commute_yeouido',
-  },
 ];
 
 export default CATEGORIES;

--- a/src/pages/Apartment/ApartmentNavigation.test.jsx
+++ b/src/pages/Apartment/ApartmentNavigation.test.jsx
@@ -23,9 +23,6 @@ describe('ApartmentNavigation', () => {
     expect(screen.getByRole('link', {
       name: /한강/,
     })).toBeInTheDocument();
-    expect(screen.getByRole('link', {
-      name: /상권/,
-    })).toBeInTheDocument();
   });
 
   it('calls handleClick upon clicking link', () => {

--- a/src/pages/Apartment/ApartmentPage.test.jsx
+++ b/src/pages/Apartment/ApartmentPage.test.jsx
@@ -42,9 +42,6 @@ describe('ApartmentPage', () => {
     expect(screen.getByRole('link', {
       name: /한강 뷰/,
     })).toBeInTheDocument();
-    expect(screen.getByRole('link', {
-      name: /상권/,
-    })).toBeInTheDocument();
 
     expect(screen.getByText('아크로리버파크')).toBeInTheDocument();
   });


### PR DESCRIPTION
As a result of GA analysis overviews over few weeks, the following apartment types have not got attention from users.
- commercial
- landscape
- commute_gangnam
- commute_gwanghwamun
- commute_yeouido

![image](https://user-images.githubusercontent.com/77006427/118078859-f3943a00-b3f1-11eb-9ccd-668cde030ab3.png)
