### PR TITLE
UIUX 💄: Enumerate all possible apartment types on home page

### DIFF
--- a/src/commons/Footer/Footer.jsx
+++ b/src/commons/Footer/Footer.jsx
@@ -5,10 +5,9 @@ import styled from '@emotion/styled';
 import { colors } from '../../designSystem';
 
 const FooterWrapper = styled.footer({
-  position: 'fixed',
   width: '100%',
-  left: '0',
-  bottom: '0',
+  margin: 'auto 0',
+
   borderTop: `1px solid ${colors.themeBorder}`,
 
   opacity: '0.8',

--- a/src/fixtures/apartments/categories.js
+++ b/src/fixtures/apartments/categories.js
@@ -2,26 +2,32 @@ const CATEGORIES = [
   {
     title: '#한강 뷰',
     url: 'riverside',
+    imgSrc: 'https://user-images.githubusercontent.com/77006427/118083436-e418ef00-b3f9-11eb-9031-c90465a50d98.png',
   },
   {
     title: '#오션 뷰',
     url: 'ocean',
+    imgSrc: 'https://user-images.githubusercontent.com/77006427/116791122-2afe0f00-aaf3-11eb-8e42-a432b04e94b2.png',
   },
   {
     title: '#펜트 하우스',
     url: 'penthouse',
+    imgSrc: 'https://user-images.githubusercontent.com/77006427/118083373-bd5ab880-b3f9-11eb-8901-0fb019fde15f.png',
   },
   {
     title: '#BTS 멤버',
     url: 'bts',
+    imgSrc: 'https://user-images.githubusercontent.com/77006427/118083161-68b73d80-b3f9-11eb-8d01-0e3badb70d6b.png',
   },
   {
     title: '#연예인',
     url: 'celebrity',
+    imgSrc: 'https://user-images.githubusercontent.com/77006427/118082668-8d5ee580-b3f8-11eb-902c-4ce1851bb57b.png',
   },
   {
     title: '#제일 비싼',
     url: 'rank',
+    imgSrc: 'https://user-images.githubusercontent.com/77006427/118088117-8be5eb00-b401-11eb-95a4-c8c10d291f3d.png',
   },
 ];
 

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import styled from '@emotion/styled';
 
+import CATEGORIES from '../../fixtures/apartments';
+
 import {
   colors,
   fontWeights,
@@ -12,46 +14,53 @@ import { LinkField } from '../../commons/Fields';
 import { Footer } from '../../commons/Footer';
 
 const HomeLayout = styled.section({
-  display: 'flex',
-  flexDirection: 'column',
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+  gridAutoRows: '1fr',
+  gap: '3rem 1rem',
+  marginBottom: '2rem',
 });
 
 const Heading = styled.h2({
   display: 'flex',
   alignItems: 'center',
-  marginBottom: '2rem',
+  paddingBottom: '1rem',
 
   color: colors.bluishGray,
   fontSize: '1.5rem',
   fontWeight: fontWeights.bold,
   lineHeight: '1.66',
+
+  borderBottom: `1px solid ${colors.bluishGray}`,
+});
+
+const Header = styled.header({
+  padding: '1rem 0',
+
+  color: colors.bluishGray,
+  fontSize: '1.2rem',
+  fontWeight: fontWeights.bold,
 });
 
 const Article = styled.article({
-  maxWidth: '400px',
-  minHeight: '60vh',
+  width: '100%',
   display: 'flex',
   flexDirection: 'column',
-  justifyContent: 'center',
-  alignItems: 'center',
-  margin: '0 auto',
 
   color: colors.white,
 
-  '& p': {
-    padding: '2rem',
+  '& button': {
+    marginBottom: '.5rem',
 
-    color: colors.bluishGray,
-    fontSize: '1.2rem',
-    fontWeight: fontWeights.bold,
-  },
-
-  '& div': {
-    padding: '2rem',
+    '&:hover': {
+      color: colors.themeColor,
+      backgroundColor: colors.white,
+    },
   },
 
   '& img': {
     width: '100%',
+    height: '200px',
     objectFit: 'cover',
 
     borderRadius: borderRadius.box,
@@ -61,29 +70,35 @@ const Article = styled.article({
 export default function Home({ onClick }) {
   return (
     <>
-      <HomeLayout>
-        <Heading>
-          돈을 얼마나 더 벌어야,
-          <br />
-          꿈 꾸시는 삶을 살 수 있는지,
-          <br />
-          알려드립니다.
-        </Heading>
 
-        <Article>
-          <p>
-            한강 뷰 아파트에 살아볼려면?
-          </p>
-          <img
-            src="http://webzine.seoulmetro.co.kr/images/0969565312_041/%EC%9E%A0%EC%8B%A4%EC%B2%A0%EA%B5%903.JPG"
-            alt="hanriver"
-          />
-          <LinkField
-            url="/apartments/riverside"
-            title="알아 보러가기"
-            onClick={onClick}
-          />
-        </Article>
+      <Heading>
+        돈을 얼마나 더 벌어야,
+        <br />
+        꿈 꾸시는 삶을 살 수 있는지,
+        <br />
+        알려드립니다.
+      </Heading>
+
+      <Header>
+        XXX 아파트에 살아볼려면?
+      </Header>
+
+      <HomeLayout>
+        {
+          CATEGORIES.map(({ title, url, imgSrc }) => (
+            <Article key={title}>
+              <LinkField
+                url={`/apartments/${url}`}
+                title={title}
+                onClick={onClick}
+              />
+              <img
+                src={imgSrc}
+                alt={title}
+              />
+            </Article>
+          ))
+        }
       </HomeLayout>
 
       <Footer />

--- a/src/pages/Home/Home.test.jsx
+++ b/src/pages/Home/Home.test.jsx
@@ -24,11 +24,14 @@ describe('Home', () => {
     jest.clearAllMocks();
   });
 
-  it('renders a link for user to check apartments', () => {
+  it('renders links of apartments', () => {
     renderHome();
 
     expect(screen.getByRole('link', {
-      name: /알아/,
+      name: /한강 뷰/,
+    })).toBeInTheDocument();
+    expect(screen.getByRole('link', {
+      name: /오션 뷰/,
     })).toBeInTheDocument();
   });
 
@@ -36,10 +39,10 @@ describe('Home', () => {
     renderHome();
 
     fireEvent.click(screen.getByRole('link', {
-      name: /알아/,
+      name: /한강 뷰/,
     }));
 
-    expect(handleClick).toBeCalledTimes(1);
+    expect(handleClick).toBeCalledWith({ url: '/apartments/riverside' });
   });
 
   it('renders footer', () => {

--- a/src/pages/Home/HomeContainer.test.jsx
+++ b/src/pages/Home/HomeContainer.test.jsx
@@ -13,7 +13,7 @@ describe('HomeContainer', () => {
     ));
 
     fireEvent.click(screen.getByRole('link', {
-      name: /알아/,
+      name: /한강 뷰/,
     }));
 
     expect(handleClick).toBeCalledWith({ url: '/apartments/riverside' });


### PR DESCRIPTION
Referring to #147 GA screenshot, Users rarely switch the apartment types
once they enter the apartment page.

Giving them options at the entry point on the home page would intrigue
users to select the apartment type they prefer to view.

![image](https://user-images.githubusercontent.com/77006427/118095458-0b2bec80-b40b-11eb-8c06-df91d832d13a.png)
