### PR TITLE
perf ⚡️: attach lazy loading attribute on the images out of viewport

### DIFF
--- a/src/pages/Apartment/Apartments.jsx
+++ b/src/pages/Apartment/Apartments.jsx
@@ -125,9 +125,10 @@ export default function Apartments({
         </Button>
       </SwitchWrapper>
 
-      {apartments?.map((apartment) => (
+      {apartments?.map((apartment, index) => (
         <Article key={apartment.name}>
           <img
+            loading={index > 1 ? 'lazy' : 'eager'}
             src={apartment.imgSrc}
             alt={apartment.name}
           />


### PR DESCRIPTION
The first two apartments are set as 'eager' since they have to be pre-loaded once users access the page.

The rest of the image of apartments loads when users actually needed to view it.

This aims for page load optimization.

See Also:
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
- https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading

![lazy_loading](https://user-images.githubusercontent.com/77006427/118275036-dac67a00-b500-11eb-9777-de1593bfefd6.gif)
